### PR TITLE
Optional academic disciplines

### DIFF
--- a/hub/apps/content/models.py
+++ b/hub/apps/content/models.py
@@ -43,8 +43,6 @@ class ContentType(TimeStampedModel):
         ('member', 'Member - AASHE Member Status Required'),
     )
 
-    ACADEMIC_DISCIPLINES_REQUIRED = False
-
     content_type = models.CharField(max_length=40)
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default=STATUS_CHOICES.new)
     permission = models.CharField(max_length=20, choices=PERMISSION_CHOICES, default=PERMISSION_CHOICES.member)
@@ -162,6 +160,17 @@ class ContentType(TimeStampedModel):
             }
         """
         return {}
+
+    @classmethod
+    def required_field_overrides(cls):
+        """
+        Each content type subclass may return a list of field names
+        which is used later in the Submit form to set the
+        'required' attribute of the respective fields.  Example:
+
+            return ['disciplines']  # makes disciplines field required
+        """
+        return []
 
 
 @python_2_unicode_compatible

--- a/hub/apps/content/models.py
+++ b/hub/apps/content/models.py
@@ -43,6 +43,8 @@ class ContentType(TimeStampedModel):
         ('member', 'Member - AASHE Member Status Required'),
     )
 
+    ACADEMIC_DISCIPLINES_REQUIRED = False
+
     content_type = models.CharField(max_length=40)
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default=STATUS_CHOICES.new)
     permission = models.CharField(max_length=20, choices=PERMISSION_CHOICES, default=PERMISSION_CHOICES.member)
@@ -78,10 +80,12 @@ class ContentType(TimeStampedModel):
         verbose_name='Sustainability Topic(s)',
         help_text="Select up to three topics that relate most closely.")
 
-    disciplines = models.ManyToManyField('metadata.AcademicDiscipline',
+    disciplines = models.ManyToManyField(
+        'metadata.AcademicDiscipline',
         verbose_name='Academic Discipline(s)',
         help_text="""Select up to three academic disciplines that relate most
-        closely to the academic program.""")
+        closely to the academic program.""",
+        blank=True)
 
     objects = ContentTypeManager()
 

--- a/hub/apps/content/types/academic.py
+++ b/hub/apps/content/types/academic.py
@@ -17,7 +17,6 @@ class AcademicProgram(ContentType):
         ('part', 'Part-Time'),
         ('both', 'Both'),
     )
-    ACADEMIC_DISCIPLINES_REQUIRED = True
 
     program_type = models.ForeignKey(ProgramType, blank=True, null=True,
         verbose_name='Program Type')
@@ -48,6 +47,10 @@ class AcademicProgram(ContentType):
             'author': 'Presenter',
             'author_plural': 'Presenters',
         }
+
+    @classmethod
+    def required_field_overrides(cls):
+        return ['disciplines']
 
     @classmethod
     def get_custom_filterset(cls):

--- a/hub/apps/content/types/academic.py
+++ b/hub/apps/content/types/academic.py
@@ -17,6 +17,7 @@ class AcademicProgram(ContentType):
         ('part', 'Part-Time'),
         ('both', 'Both'),
     )
+    ACADEMIC_DISCIPLINES_REQUIRED = True
 
     program_type = models.ForeignKey(ProgramType, blank=True, null=True,
         verbose_name='Program Type')

--- a/hub/apps/content/types/centers.py
+++ b/hub/apps/content/types/centers.py
@@ -13,8 +13,6 @@ class CenterAndInstitute(ContentType):
     budget = models.PositiveIntegerField('Total operating budget for the center or institute (excluding salaries)?',
         blank=True, null=True, help_text='in U.S. dollars')
 
-    ACADEMIC_DISCIPLINES_REQUIRED = True
-
     class Meta:
         verbose_name = 'Research Center & Institute'
         verbose_name_plural = 'Research Centers & Institutes'
@@ -24,6 +22,10 @@ class CenterAndInstitute(ContentType):
         return {
             'title': 'Center Name',
         }
+
+    @classmethod
+    def required_field_overrides(cls):
+        return ['disciplines']
 
 
 class CenterAndInstituteIndex(BaseIndex):

--- a/hub/apps/content/types/centers.py
+++ b/hub/apps/content/types/centers.py
@@ -13,6 +13,8 @@ class CenterAndInstitute(ContentType):
     budget = models.PositiveIntegerField('Total operating budget for the center or institute (excluding salaries)?',
         blank=True, null=True, help_text='in U.S. dollars')
 
+    ACADEMIC_DISCIPLINES_REQUIRED = True
+
     class Meta:
         verbose_name = 'Research Center & Institute'
         verbose_name_plural = 'Research Centers & Institutes'

--- a/hub/apps/content/types/courses.py
+++ b/hub/apps/content/types/courses.py
@@ -17,6 +17,7 @@ class Material(ContentType):
         ('intermediate', 'Intermediate'),
         ('advanced', 'Advanced'),
     )
+    ACADEMIC_DISCIPLINES_REQUIRED = True
 
     website = models.URLField('Website', blank=True, null=True)
     document = models.FileField('Document Upload',

--- a/hub/apps/content/types/courses.py
+++ b/hub/apps/content/types/courses.py
@@ -17,7 +17,6 @@ class Material(ContentType):
         ('intermediate', 'Intermediate'),
         ('advanced', 'Advanced'),
     )
-    ACADEMIC_DISCIPLINES_REQUIRED = True
 
     website = models.URLField('Website', blank=True, null=True)
     document = models.FileField('Document Upload',
@@ -37,6 +36,10 @@ class Material(ContentType):
     class Meta:
         verbose_name = 'Course Material'
         verbose_name_plural = 'Course Materials'
+
+    @classmethod
+    def required_field_overrides(cls):
+        return ['disciplines']
 
 
 class MaterialIndex(BaseIndex):

--- a/hub/apps/submit/forms.py
+++ b/hub/apps/submit/forms.py
@@ -30,11 +30,6 @@ class SubmitResourceForm(forms.ModelForm):
             'published',
         )
 
-    def __init__(self, *args, **kwargs):
-        super(SubmitResourceForm, self).__init__(*args, **kwargs)
-        if self.instance.ACADEMIC_DISCIPLINES_REQUIRED:
-            self.fields['disciplines'].required = True
-
     def save(self, request):
         self.instance.submitted_by = request.user
         obj = super(SubmitResourceForm, self).save()

--- a/hub/apps/submit/forms.py
+++ b/hub/apps/submit/forms.py
@@ -30,6 +30,11 @@ class SubmitResourceForm(forms.ModelForm):
             'published',
         )
 
+    def __init__(self, *args, **kwargs):
+        super(SubmitResourceForm, self).__init__(*args, **kwargs)
+        if self.instance.ACADEMIC_DISCIPLINES_REQUIRED:
+            self.fields['disciplines'].required = True
+
     def save(self, request):
         self.instance.submitted_by = request.user
         obj = super(SubmitResourceForm, self).save()

--- a/hub/apps/submit/views.py
+++ b/hub/apps/submit/views.py
@@ -104,6 +104,11 @@ class SubmitFormView(LoginRequiredMixin, FormView):
             if field in DocumentForm.base_fields:
                 DocumentForm.base_fields[field].label = label
 
+        # If the content type provides required overrides, update them
+        for field in self.content_type_class.required_field_overrides():
+            if field in DocumentForm.base_fields:
+                DocumentForm.base_fields[field].required = True
+
         # Additional formsets
         AuthorFormset = formset_factory(AuthorForm, min_num=0, max_num=5, extra=5)
         ImageFormSet = formset_factory(ImageForm, min_num=0, max_num=3, extra=3)


### PR DESCRIPTION
Makes Academic Disciplines an optional field for all content types except Academic Programs, Research Centers & Institutes, and Course Materials, where they're required by the SubmitResourceForm.

Closes https://github.com/AASHE/hub/issues/85.