### PR TITLE
Configure Sentry logging

### DIFF
--- a/hub/settings/server.py
+++ b/hub/settings/server.py
@@ -68,6 +68,13 @@ else:
     STATIC_ROOT = 'staticfiles'
 
 # ==============================================================================
+# Sentry Error Logging
+# ==============================================================================
+
+from integration_settings.logging.sentry import *
+INSTALLED_APPS += ('raven.contrib.django.raven_compat',)
+
+# ==============================================================================
 # Enable debug logging
 # ==============================================================================
 # LOGGING['loggers']['hub']['level'] = 'DEBUG'

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ dj-database-url
 gunicorn
 ipython
 psycopg2
+raven==5.10.2
 whitenoise
 
 # Non-pypi repos


### PR DESCRIPTION
Note update to requirements.txt (for raven) and dependence on new version of
django-integration-settings (v0.0.2).