### PR TITLE
Scott cosmetic tickets

### DIFF
--- a/hub/apps/content/models.py
+++ b/hub/apps/content/models.py
@@ -180,6 +180,9 @@ class ContentType(TimeStampedModel):
         for image in self.images.all():
             thumbnail_image.delay(image.pk, recreate=recreate)
 
+    def get_organization_list(self):
+        return list(self.organizations.all())
+
     @classmethod
     def content_type_label(cls):
         """

--- a/hub/templates/base.html
+++ b/hub/templates/base.html
@@ -64,8 +64,8 @@
         <div class="col-md-5 col-sm-12">
           <form class="search" action="{% url "browse:browse" %}" method="GET">
             <input type="text" name="search" class="form-control" placeholder="Search Hub" value="{{ request.GET.search }}">
-            <button class="btn-u all-resources" type="submit">Go</button>
-            <a class="btn btn-u all-resources" href="{% url "browse:browse" %}?search=">All Resources</a>
+            <button class="btn-u all-resources" type="submit">Search</button>
+            <a class="btn btn-u all-resources" href="{% url "browse:browse" %}?search=">Browse All</a>
           </form>
         </div>
       </div>

--- a/hub/templates/browse/details/base.html
+++ b/hub/templates/browse/details/base.html
@@ -187,12 +187,12 @@
 
                 {# ========================================================== #}
 
-                {% if object.websites.all or object.files.all %}
                 <hr>
                 <div class="panel panel-profile">
                     <div class="panel-heading overflow-h">
                         <h2 class="panel-title heading-sm pull-left"><i class="icon  icon-folder"></i> Links and Materials</h2>
                     </div>
+                {% if object.websites.all or object.files.all %}
                     <div class="panel-body">
                         <ul class="list-unstyled social-contacts-v3">
                             <!-- Websites -->
@@ -212,8 +212,12 @@
                             {% endfor %}
                         </ul>
                     </div>
-                </div>
+                {% else %}
+                    <div class="panel-body">
+                        The submitter of this resource did not include any associated files or links.
+                    </div>
                 {% endif %}
+                </div>
 
 
             <!-- /inner body -->

--- a/hub/templates/browse/details/casestudy.html
+++ b/hub/templates/browse/details/casestudy.html
@@ -10,9 +10,19 @@
     <div><strong>Program Type:</strong> {{ object.program_type.name }}</div>
     {% endif %}
 
-    {% if object.institution %}
-    <div><strong>Institution:</strong> {{ object.institution.name }}</div>
-    {% endif %}
+    <div>
+        <strong>Institution:</strong>
+        {% with object.get_organization_list as orgs %}
+            {% if orgs %}
+                <div>
+                    <strong>Institution:</strong>
+                    {% for org in orgs %}
+                        {{ org }}{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
+                </div>
+            {% endif %}
+        {% endwith %}
+    </div>
 {% endblock %}
 
 

--- a/hub/templates/browse/details/centerandinstitute.html
+++ b/hub/templates/browse/details/centerandinstitute.html
@@ -4,7 +4,16 @@
 
 {% block resource_metadata %}
     <div class="margin-bottom-10"></div>
-    {% include "browse/details/includes/meta.html" with label="Institution" value=object.institution.name %}
+    {% with object.get_organization_list as orgs %}
+        {% if orgs %}
+            <div>
+                <strong>Institution:</strong>
+                {% for org in orgs %}
+                    {{ org }}{% if not forloop.last %}, {% endif %}
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
     {% include "browse/details/includes/meta.html" with label="Total Budget" value=object.budget %}
     {% include "browse/details/includes/meta.html" with label="Number of Paid Staff" value=object.num_paid %}
 {% endblock %}

--- a/hub/templates/browse/details/photograph.html
+++ b/hub/templates/browse/details/photograph.html
@@ -4,7 +4,16 @@
 
 {% block resource_metadata %}
     <div class="margin-bottom-10"></div>
-    {% include "browse/details/includes/meta.html" with label="institution" value=object.institution.name %}
+    {% with object.get_organization_list as orgs %}
+        {% if orgs %}
+            <div>
+                <strong>Institution:</strong>
+                {% for org in orgs %}
+                    {{ org }}{% if not forloop.last %}, {% endif %}
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
 {% endblock %}
 
 {% block resource_content %}

--- a/hub/templates/browse/details/presentation.html
+++ b/hub/templates/browse/details/presentation.html
@@ -4,8 +4,16 @@
 
 {% block resource_metadata %}
     <div class="margin-bottom-10"></div>
-    {% include "browse/details/includes/meta.html" with label="institution" value=object.institution.name %}
-    {% include "browse/details/includes/meta.html" with label="Conference" value=object.get_conf_name_display %}
-    {% include "browse/details/includes/meta.html" with label="Type" value=object.get_presentation_type_display %}
+    {% include "browse/details/includes/meta.html" with label="Conference" value=object.conf_name %}
+    {% include "browse/details/includes/meta.html" with label="Type" value=object.presentation_type %}
+    {% with object.get_organization_list as orgs %}
+        {% if orgs %}
+            <div>
+                <strong>Institution:</strong>
+                {% for org in orgs %}
+                    {{ org }}{% if not forloop.last %}, {% endif %}
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
 {% endblock %}
-

--- a/hub/templates/browse/details/publication.html
+++ b/hub/templates/browse/details/publication.html
@@ -7,5 +7,14 @@
     {% include "browse/details/includes/meta.html" with label="Publisher" value=object.publisher %}
     {% include "browse/details/includes/meta.html" with label="Periodical Name" value=object.periodical_name %}
     {% include "browse/details/includes/meta.html" with label="Type" value=object.get__type_display %}
-    {% include "browse/details/includes/meta.html" with label="Institution" value=object.institution.name %}
+    {% with object.get_organization_list as orgs %}
+        {% if orgs %}
+            <div>
+                <strong>Institution:</strong>
+                {% for org in orgs %}
+                    {{ org }}{% if not forloop.last %}, {% endif %}
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
 {% endblock %}

--- a/hub/templates/browse/details/tool.html
+++ b/hub/templates/browse/details/tool.html
@@ -4,7 +4,16 @@
 
 {% block resource_metadata %}
     <div class="margin-bottom-10"></div>
-    {% include "browse/details/includes/meta.html" with label="Institution" value=object.institution.name %}
+    {% with object.get_organization_list as orgs %}
+        {% if orgs %}
+            <div>
+                <strong>Institution:</strong>
+                {% for org in orgs %}
+                    {{ org }}{% if not forloop.last %}, {% endif %}
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
 {% endblock %}
 
 

--- a/hub/templates/browse/details/video.html
+++ b/hub/templates/browse/details/video.html
@@ -4,5 +4,14 @@
 
 {% block resource_metadata %}
     <div class="margin-bottom-10"></div>
-    {% include "browse/details/includes/meta.html" with label="Institution" value=object.institution.name %}
+    {% with object.get_organization_list as orgs %}
+        {% if orgs %}
+            <div>
+                <strong>Institution:</strong>
+                {% for org in orgs %}
+                    {{ org }}{% if not forloop.last %}, {% endif %}
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
 {% endblock %}

--- a/hub/templates/browse/results/includes/summary.html
+++ b/hub/templates/browse/results/includes/summary.html
@@ -8,7 +8,7 @@
         $(document.getElementById("resource-tab")).attr('class', 'active');
         $(document.getElementById("resource-toggle")).attr('aria-expanded', true);
         $(document.getElementById("summary-tab")).attr('class', '');
-        $(document.getElementById("summary-toggle")).attr('aria-expanded', flase);
+        $(document.getElementById("summary-toggle")).attr('aria-expanded', false);
     }
 </script>
 

--- a/hub/templates/browse/results/includes/toolkit.html
+++ b/hub/templates/browse/results/includes/toolkit.html
@@ -2,20 +2,30 @@
 {% load browse_tags %}
 {% load typogrify_tags %}
 
+<script type="text/javascript">
+    function switchTab(){
+        $(document.getElementById("resources-tab")).attr('class', 'active');
+        $(document.getElementById("resources-toggle")).attr('aria-expanded', true);
+        $(document.getElementById("toolkit-tab")).attr('class', '');
+        $(document.getElementById("toolkit-toggle")).attr('aria-expanded', false);
+    }
+</script>
+
 <div class="container profile">
 <div class="row">
   <div class="col-md-8 profile-body">
-
     {% if topic.introduction %}
-    <div class="panel">
-        <div class="panel-heading overflow-h">
-            <h2 class="panel-title heading-sm pull-left"><i class="fa  fa-info"></i> Introduction</h2>
+        <div class="panel">
+            <div class="panel-heading overflow-h">
+                <h2 class="panel-title heading-sm pull-left"><i class="fa  fa-info"></i> Introduction</h2>
+            </div>
+            <div class="panel-body">
+                {{ topic.introduction|apply_markup:"markdown" }}
+                <a class="btn-u" data-toggle="tab" onclick="switchTab()" href="#resources">View all {{ page_title }}</a>
+                <a class="btn-u" href="{% url "submit:new" %}"><i class="fa fa-rocket"></i> Submit a new resource</a>
+            </div>
         </div>
-        <div class="panel-body">
-            {{ topic.introduction|apply_markup:"markdown" }}
-        </div>
-    </div>
-    <div class="margin-bottom-30"></div>
+        <div class="margin-bottom-30"></div>
     {% endif %}
 
     {% if featured_list %}

--- a/hub/templates/browse/results/topic.html
+++ b/hub/templates/browse/results/topic.html
@@ -6,11 +6,11 @@
 {% block body_class %}page-browse-topic{% endblock %}
 
 {% block browse_additional_tabs %}
-    <li class="{% if not request.GET %}active{% endif %}">
-        <a data-toggle="tab" href="#toolkit" aria-expanded="{% if request.GET %}false{% else %}true{% endif %}">Toolkit</a>
+    <li id="toolkit-tab" class="{% if not request.GET %}active{% endif %}">
+        <a id="toolkit-toggle" data-toggle="tab" href="#toolkit" aria-expanded="{% if request.GET %}false{% else %}true{% endif %}">Toolkit</a>
     </li>
-    <li class="{% if request.GET %}active{% endif %}">
-        <a data-toggle="tab" href="#resources" aria-expanded="{% if request.GET %}true{% else %}false{% endif %}">Resources</a>
+    <li id="resources-tab" class="{% if request.GET %}active{% endif %}">
+        <a id="resources-toggle" data-toggle="tab" href="#resources" aria-expanded="{% if request.GET %}true{% else %}false{% endif %}">Resources</a>
     </li>
     <li>
         <a data-toggle="tab" href="#stars">STARS Data</a>

--- a/hub/templates/content/resource_approved_email.html
+++ b/hub/templates/content/resource_approved_email.html
@@ -22,7 +22,7 @@
     </p>
 
     <ul>
-      <li>Resource title: {{ resource.title|titlecase }}</li>
+      <li>Resource title: {{ resource.title }}</li>
       <li>Content type: {{ resource.content_type_label }}</li>
       <li>Submitter name: {{ resource.submitted_by.get_full_name }}</li>
       <li>Link to resource:

--- a/hub/templates/content/resource_approved_email.txt
+++ b/hub/templates/content/resource_approved_email.txt
@@ -10,7 +10,7 @@ Thank you for contributing to AASHE’s Campus Sustainability Hub! The
 following resource has been approved and is now accessible through the
 Hub.
 
-  - Resource title: {{ resource.title|titlecase }}
+  - Resource title: {{ resource.title }}
   - Content type: {{ resource.content_type_label }}
   - Submitter name: {{ resource.submitted_by.get_full_name }}
   - Link to resource:

--- a/hub/templates/content/resource_declined_email.html
+++ b/hub/templates/content/resource_declined_email.html
@@ -23,7 +23,7 @@
     </p>
 
     <ul>
-      <li>Resource title: {{ resource.title|titlecase }}</li>
+      <li>Resource title: {{ resource.title }}</li>
       <li>Content type: {{ resource.content_type_label }}</li>
       <li>Submitter name: {{ resource.submitted_by.get_full_name }}</li>
     </ul>

--- a/hub/templates/content/resource_declined_email.txt
+++ b/hub/templates/content/resource_declined_email.txt
@@ -11,7 +11,7 @@ Hub.  We reviewed your submission and have decided not to post the
 following resource at this time as it does not appear to meet our
 Campus Sustainability Hub Submission Guidelines.
 
-  - Resource title: {{ resource.title|titlecase }}
+  - Resource title: {{ resource.title }}
   - Content type: {{ resource.content_type_label }}
   - Submitter name: {{ resource.submitted_by.get_full_name }}
 

--- a/hub/templates/submit/resource_submitted_email.txt
+++ b/hub/templates/submit/resource_submitted_email.txt
@@ -2,7 +2,7 @@
 
 A new resource has been submitted and is ready for review:
 
-  - Resource title: {{ resource.title|titlecase }}
+  - Resource title: {{ resource.title }}
   - Content type: {{ resource.content_type_label }}
   - Submitted by:
     - Name: {{ resource.submitted_by.get_full_name }}


### PR DESCRIPTION
Lumped all of the minor display tickets into a single PR for efficiency.

Changelog:

* #393: Adds display of conference name metadata. Brought to my attention a bug with displaying the "Institution" (this is not an attribute of a ContentType). Added a method to the base CT class to pack up a list of associated Orgs, which is now correctly displayed instead.

* #375: Relabeled buttons as per request in issue.

* #351: Added buttons to the toolkit intro blocks to mirror what is present in the new content type summary tabs.

* #359: Added helptext for when no files or links are present in the "Links and Materials" block, rather than having the block just disappear entirely.

* #367: Removed use of titlecase filter from all email templates.