### PR TITLE
Re-center search results pagination under results list; Issue #411

### DIFF
--- a/hub/templates/browse/results/base.html
+++ b/hub/templates/browse/results/base.html
@@ -106,8 +106,8 @@
                         <div class="no-results">No resources match your current filter settings.</div>
                     {% endif %}
                 {% endblock %}
+                {% include "browse/results/includes/pagination.html" %}
             </div>
-            {% include "browse/results/includes/pagination.html" %}
         </div>
     </div>
     <!-- end cache -->


### PR DESCRIPTION
Re-center search results pagination under search results list.

Resolves: #411 