### PR TITLE
Sort green power projects by project size; Issue #471

### DIFF
--- a/hub/apps/browse/filter.py
+++ b/hub/apps/browse/filter.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db.models import Q
 from django.utils.timezone import now
+from django.db.models import FloatField, ExpressionWrapper, F
 
 from haystack.inputs import Raw
 from haystack.query import SearchQuerySet
@@ -376,7 +377,10 @@ class GreenPowerOrderingFilter(filters.ChoiceFilter):
             list_of_pks = []
             for ob in qs:
                 list_of_pks.append(ob.pk)
-            return GreenPowerProject.objects.filter(pk__in=list_of_pks).order_by('project_size')
+            return (GreenPowerProject.objects.filter(pk__in=list_of_pks)
+                            .extra({'casted_project_size':
+                            "CAST(replace(project_size, ',', '') as real)"})
+                            .order_by('-casted_project_size'))
         return qs.order_by(value)
 
 

--- a/hub/apps/browse/filter.py
+++ b/hub/apps/browse/filter.py
@@ -352,6 +352,31 @@ class OrderingFilter(filters.ChoiceFilter):
         return qs.order_by(value)
 
 
+class GreenPowerOrderingFilter(filters.ChoiceFilter):
+    field_class = forms.fields.ChoiceField
+
+    def __init__(self, *args, **kwargs):
+        kwargs.update({
+            'choices': (
+                ('title', 'Title'),
+                ('content_type', 'Content Type'),
+                ('-published', 'Date Posted'),
+                ('-date_created', 'Date Created, Published, Presented'),
+                ('-project_size', 'Project Size')
+            ),
+            'label': 'Sort by:',
+            'widget': forms.widgets.RadioSelect,
+        })
+        super(GreenPowerOrderingFilter, self).__init__(*args, **kwargs)
+
+    def filter(self, qs, value):
+        if not value:
+            return qs.order_by('-published')
+        if value == 'Project Size':
+            raise 'Yellow!'
+        return qs.order_by(value)
+
+
 # Academic Program specific
 class ProgramTypeFilter(filters.ChoiceFilter):
     """

--- a/hub/apps/browse/filter.py
+++ b/hub/apps/browse/filter.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db.models import Q
 from django.utils.timezone import now
-from django.db.models import FloatField, ExpressionWrapper, F
 
 from haystack.inputs import Raw
 from haystack.query import SearchQuerySet

--- a/hub/apps/browse/filter.py
+++ b/hub/apps/browse/filter.py
@@ -362,7 +362,7 @@ class GreenPowerOrderingFilter(filters.ChoiceFilter):
                 ('content_type', 'Content Type'),
                 ('-published', 'Date Posted'),
                 ('-date_created', 'Date Created, Published, Presented'),
-                ('-project_size', 'Project Size')
+                ('greenpowerproject', 'Project Size')
             ),
             'label': 'Sort by:',
             'widget': forms.widgets.RadioSelect,
@@ -372,8 +372,11 @@ class GreenPowerOrderingFilter(filters.ChoiceFilter):
     def filter(self, qs, value):
         if not value:
             return qs.order_by('-published')
-        if value == 'Project Size':
-            raise 'Yellow!'
+        if value == 'greenpowerproject':
+            list_of_pks = []
+            for ob in qs:
+                list_of_pks.append(ob.pk)
+            return GreenPowerProject.objects.filter(pk__in=list_of_pks).order_by('project_size')
         return qs.order_by(value)
 
 

--- a/hub/apps/browse/filterset.py
+++ b/hub/apps/browse/filterset.py
@@ -76,33 +76,13 @@ class CenterAndInstituteBrowseFilterSet(ExlcudeGalleryFilterMixin,
     created = CreatedFilter(CenterAndInstitute)
 
 
-class GreenPowerBrowseFilterSet(filters.FilterSet):
-    search = SearchFilter(widget=forms.HiddenInput)
-    gallery_view = GalleryFilter()
-    content_type = ContentTypesFilter()
-    topics = TopicFilter()
-    discipline = DisciplineFilter()
-    institutional_office = InstitutionalOfficeFilter()
-    tagfilter = TagFilter('tags')
-    organizations = OrganizationFilter()
-    institution_types = InstitutionTypeFilter()
-    size = StudentFteFilter()
-    country = CountryFilter(required=False)
-    state = StateFilter(required=False)
-    province = ProvinceFilter(required=False)
-    published = PublishedFilter()
-    created = CreatedFilter()
+class GreenPowerBrowseFilterSet(GenericFilterSet):
     installation = GreenPowerInstallationFilter()
     ownership = GreenPowerOwnershipFilter()
     project_size = GreenPowerProjectSizeFilter()
     created = CreatedFilter(GreenPowerProject)
     order = GreenPowerOrderingFilter()
 
-    class Meta:
-        model = ContentType
-        #  Don't set any automatic fields, we already defined
-        # a specific list above.
-        fields = []
 
 class MaterialBrowseFilterSet(ExlcudeGalleryFilterMixin, GenericFilterSet):
     material_type = MaterialTypeFilter()

--- a/hub/apps/browse/filterset.py
+++ b/hub/apps/browse/filterset.py
@@ -75,13 +75,34 @@ class CenterAndInstituteBrowseFilterSet(ExlcudeGalleryFilterMixin,
     created = CreatedFilter(CenterAndInstitute)
 
 
-class GreenPowerBrowseFilterSet(GenericFilterSet):
+class GreenPowerBrowseFilterSet(filters.FilterSet):
+    search = SearchFilter(widget=forms.HiddenInput)
+    gallery_view = GalleryFilter()
+    content_type = ContentTypesFilter()
+    topics = TopicFilter()
+    discipline = DisciplineFilter()
+    institutional_office = InstitutionalOfficeFilter()
+    tagfilter = TagFilter('tags')
+    organizations = OrganizationFilter()
+    institution_types = InstitutionTypeFilter()
+    size = StudentFteFilter()
+    country = CountryFilter(required=False)
+    state = StateFilter(required=False)
+    province = ProvinceFilter(required=False)
+    published = PublishedFilter()
+    created = CreatedFilter()
     installation = GreenPowerInstallationFilter()
     ownership = GreenPowerOwnershipFilter()
     project_size = GreenPowerProjectSizeFilter()
+    order = GreenPowerOrderingFilter()
     from ..content.types.green_power_projects import GreenPowerProject
     created = CreatedFilter(GreenPowerProject)
 
+    class Meta:
+        model = ContentType
+        #  Don't set any automatic fields, we already defined
+        # a specific list above.
+        fields = []
 
 class MaterialBrowseFilterSet(ExlcudeGalleryFilterMixin, GenericFilterSet):
     material_type = MaterialTypeFilter()

--- a/hub/apps/browse/filterset.py
+++ b/hub/apps/browse/filterset.py
@@ -1,5 +1,6 @@
 from .filter import *
 from collections import OrderedDict
+from ..content.types.green_power_projects import GreenPowerProject
 
 
 class GenericFilterSet(filters.FilterSet):
@@ -94,9 +95,8 @@ class GreenPowerBrowseFilterSet(filters.FilterSet):
     installation = GreenPowerInstallationFilter()
     ownership = GreenPowerOwnershipFilter()
     project_size = GreenPowerProjectSizeFilter()
-    order = GreenPowerOrderingFilter()
-    from ..content.types.green_power_projects import GreenPowerProject
     created = CreatedFilter(GreenPowerProject)
+    order = GreenPowerOrderingFilter()
 
     class Meta:
         model = ContentType


### PR DESCRIPTION
Add GreenPowerOrderingFilter to sort green power projects by 'project_size.'

The 'project_size' field is listed in the model as a CharField. To order by size, a temporary value must be created in the query for each QuerySet object, which casts the value of 'project_size' to a numeric value. I called this 'casted_project_size.' In order to cast these string values to numeric values, the commas must be removed.

Resolves: #471 