### PR TITLE
Update to ISS v2.6, to expose ISS in admin; Issue #488

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ newrelic
 
 # Non-pypi repos
 https://github.com/AASHE/django-aashe-theme/archive/1.10.8.zip
-https://github.com/AASHE/iss/archive/v2.5.10.zip
+https://github.com/AASHE/iss/archive/v2.6.zip
 
 https://github.com/AASHE/django-block-content/archive/v0.0.3.zip
 https://github.com/jamstooks/django-cache-url/archive/master.zip


### PR DESCRIPTION
Update to ISS v2.6.

This should allow admins to manually manage data in the Admin.

Resolves #488 