### PR TITLE
Update iss to 2.6.3, and fix spelling mistake in template

### DIFF
--- a/hub/templates/browse/details/greenpowerproject.html
+++ b/hub/templates/browse/details/greenpowerproject.html
@@ -80,7 +80,7 @@
     <div class="margin-bottom-30"></div>
     <div class="panel panel-profile">
         <div class="panel-heading overflow-h">
-            <h2 class="panel-title heading-sm pull-left">Describe the cost savings the instituion expects to generate through this project, including how these savings were calculated</h2>
+            <h2 class="panel-title heading-sm pull-left">Describe the cost savings the institution expects to generate through this project, including how these savings were calculated</h2>
         </div>
         <div class="panel-body">{{ object.cost_savings_desc|apply_markup:"markdown" }}</div>
     </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ newrelic
 
 # Non-pypi repos
 https://github.com/AASHE/django-aashe-theme/archive/1.10.8.zip
-https://github.com/AASHE/iss/archive/v2.6.2.zip
+https://github.com/AASHE/iss/archive/v2.6.3.zip
 
 https://github.com/AASHE/django-block-content/archive/v0.0.3.zip
 https://github.com/jamstooks/django-cache-url/archive/master.zip


### PR DESCRIPTION
Update iss to 2.6.3, which displays membersuite_id in the ISS Orgs admin. Allows for searching of exact match of membersuite_id.

Fix spelling mistake in template in greenpowerproject.html.