### PR TITLE
Allow only published gpps in gpp size range filter

### DIFF
--- a/hub/apps/browse/filter.py
+++ b/hub/apps/browse/filter.py
@@ -514,7 +514,7 @@ class GreenPowerProjectSizeFilter(filters.ChoiceFilter):
             return qs
         from ..content.types.green_power_projects import GreenPowerProject
 
-        sizes = [(pk, int(float(size.replace(',', '')))) for pk, size in GreenPowerProject.objects.values_list('pk', 'project_size')]
+        sizes = [(pk, int(float(size.replace(',', '')))) for pk, size in GreenPowerProject.objects.filter(status='published').values_list('pk', 'project_size')]
 
         gpp_pks = []
         for value in values:


### PR DESCRIPTION
Fix 500 error, by only allowing published gpps in gpps size range filter.