### PR TITLE
Remove ads from toolkit

### DIFF
--- a/hub/templates/browse/results/includes/toolkit.html
+++ b/hub/templates/browse/results/includes/toolkit.html
@@ -81,7 +81,8 @@
 
         {% if new_resources_list %}
         <div class="panel">
-          {% include "browse/results/includes/topic_ad.html" %}
+          <!-- remove the advertisement -->
+          <!-- {% include "browse/results/includes/topic_ad.html" %} -->
             <div class="panel-heading overflow-h">
                 <h2 class="panel-title heading-sm pull-left"><i class="fa  fa-certificate"></i> New Resources</h2>
             </div>


### PR DESCRIPTION
Comment out the line which includes the ads in the toolkit. Leave the code in place, in the even that we sell any ads, it will make it much easier to reincorporate.