### PR TITLE
Revert changes to url masking

### DIFF
--- a/hub/apps/browse/templatetags/browse_tags.py
+++ b/hub/apps/browse/templatetags/browse_tags.py
@@ -126,10 +126,5 @@ def mask_url(link):
     begin = "https://hub-media.aashe.org/uploads/"
     if "amazonaws.com" in link:
         end = link.rpartition('/')[2]
-        if ".pdf" in end:
-            return (begin + end).replace("+", "%2B")
-        else:
-            return begin + end
-    elif ".pdf" in link:
-        return link.replace("+", "%2B")
+        return begin + end
     return link

--- a/hub/tests/test_browse.py
+++ b/hub/tests/test_browse.py
@@ -330,15 +330,3 @@ class MaskUrlTagTestCase(WithUserSuperuserTestCase):
         aws_url = "https://s3-us-west-2.amazonaws.com/a/b/end"
         mutated = mask_url(aws_url)
         self.assertEqual("https://hub-media.aashe.org/uploads/end", mutated)
-
-    def test_plus_is_not_replaced(self):
-        plus_url = "https://s3-us-west-2.amazonaws.com/a/b/end+end"
-        mutated = mask_url(plus_url)
-        self.assertEqual(
-            "https://hub-media.aashe.org/uploads/end+end", mutated)
-
-    def test_plus_is_replaced(self):
-        plus_url = "https://s3-us-west-2.amazonaws.com/a/b/end+end.pdf"
-        mutated = mask_url(plus_url)
-        self.assertEqual(
-            "https://hub-media.aashe.org/uploads/end%2Bend.pdf", mutated)


### PR DESCRIPTION
Revert changes in url masking so that all resources may be downloaded. Issues with aws character escaping must be researched further.